### PR TITLE
Removing CI trigger on main updates

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,7 @@
-trigger:
-  - main
+# automatic trigger when a git branch on the repo updates. Set to None, because all code changes
+# go through Pull Requests, which also trigger a CI run. So having this track the main branch just gives
+# duplicate CI runs.
+trigger: none
 
 variables:
   BUILDOZER_SYSTEM_DIR: /home/vsts/.buildozer


### PR DESCRIPTION
Azure pipelines currently runs a test and build run for every PR opened. Since all code changes come through PR's, we don't also need to make a build when the main branch is updated (by merging a PR). So I'm just setting the branch trigger to None.